### PR TITLE
add hf-token

### DIFF
--- a/retrieval_qa_benchmark/models/tgi.py
+++ b/retrieval_qa_benchmark/models/tgi.py
@@ -1,6 +1,6 @@
 import re
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from huggingface_hub import InferenceClient
 
@@ -26,11 +26,12 @@ class TGI_LLM(BaseLLM):
         name: str = "llama2-13b-chat-hf",
         backend_url: str = "http://127.0.0.1:8080",
         system_prompt: Optional[str] = None,
+        hf_token: Union[str, bool, None] = None,
         run_args: Optional[Dict[str, Any]] = None,
         stream: bool = False,
         **kwargs: Any,
     ) -> "TGI_LLM":
-        client = InferenceClient(model=backend_url)
+        client = InferenceClient(model=backend_url, token=hf_token)
         return cls(
             name=name,
             client=client,


### PR DESCRIPTION
<!--
Thank you for contributing to RQABench! 

Please fill our the section below before you submit your PR
-->

## 📝 Description

<!--write down what your PR fixed or added-->

Add hf_token for `TGI_LLM`

By adding `hf_token` to the configuration, you can use gated Inference API from huggingface now.

```python
from retrieval_qa_benchmark.models import *
from retrieval_qa_benchmark.utils.factory import ModelFactory
from retrieval_qa_benchmark.utils.registry import REGISTRY
print(REGISTRY)

config = {
    "type": "tgi",
    "args": {
        "name": "Mistral-7B-v0.1",
        "backend_url": "https://api-inference.huggingface.co/models/mistralai/Mistral-7B-v0.1",
        # here is where you add your token, you can insert this into your yaml configuration too!
        "hf_token": "xxxx",
    },
    "run_args": {
        "max_new_tokens": 30,
        "stop_sequences": [".\n\n",],
    }
}

model = ModelFactory.from_config(config).build()
output = model.generate("Hello there? Can you tell me about yourself?")
```
## ❕ Linked Issue

<!--If there is any linked issue-->

## 👷 Maintainer

<!--
    Overall: @mpskex
-->